### PR TITLE
Tune Dependabot automation schedules for normal schedule and pin alignment repos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+      time: "21:49"
+      timezone: UTC
     commit-message:
       prefix: "chore(deps):"
     labels:
@@ -30,6 +32,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+      time: "21:49"
+      timezone: UTC
     commit-message:
       prefix: "chore(deps):"
     labels:

--- a/.github/workflows/dependabot-automerge-cron.yml
+++ b/.github/workflows/dependabot-automerge-cron.yml
@@ -2,8 +2,8 @@ name: Dependabot Auto-merge (Cron)
 
 on:
   schedule:
-    # Run daily at 20:00 UTC
-    - cron: '0 20 * * *'
+    # Run at 00:49, 08:49, and 16:49 UTC
+    - cron: '49 0,8,16 * * *'
   workflow_dispatch: {}
 
 permissions:
@@ -15,6 +15,6 @@ jobs:
   check-aged-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: cmiic/dependabot-automation/cron@0c76ac0afb22cc9f83af08ac65673e609be3ac62 # v1.2.0
+      - uses: cmiic/dependabot-automation/cron@5ed389108eab8ee3ec9a1ce78f91405fcd13f166 # v1.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,6 +16,6 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - uses: cmiic/dependabot-automation/merge@0c76ac0afb22cc9f83af08ac65673e609be3ac62 # v1.2.0
+      - uses: cmiic/dependabot-automation/merge@5ed389108eab8ee3ec9a1ce78f91405fcd13f166 # v1.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Move Dependabot version update checks to daily UTC timing at 21:49 UTC.
- Change the automerge cron to run every 8 hours at 00:49, 08:49, and 16:49 UTC.
- Align shared merge and cron wrappers to cmiic/dependabot-automation v1.4.0 where needed.