### PR TITLE
chore(ci): harden workflows and unblock dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge-cron.yml
+++ b/.github/workflows/dependabot-automerge-cron.yml
@@ -14,7 +14,9 @@ permissions:
 jobs:
   check-aged-prs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: cmiic/dependabot-automation/cron@6da55a5ce4f786ac1ec1c84b997b713ce28178c2 # v2.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          quarantine-days: "1"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,7 +15,9 @@ permissions:
 jobs:
   automerge:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: cmiic/dependabot-automation/merge@6da55a5ce4f786ac1ec1c84b997b713ce28178c2 # v2.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          quarantine-days: "1"

--- a/.github/workflows/makecode.yml
+++ b/.github/workflows/makecode.yml
@@ -14,6 +14,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -29,6 +30,7 @@ jobs:
     name: Build
     needs: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 


### PR DESCRIPTION
- Add `timeout-minutes: 15` to every job. Without it a hung job holds a runner for the 6 h default.
- Set `quarantine-days: "1"` on the Dependabot auto-merge actions. GitHub already waits 3 days before opening the PR, so one more day of quarantine is enough.