### PR TITLE
ci(dependabot): merge on the PR event and gate the job on dependabot

### DIFF
--- a/.github/workflows/dependabot-automerge-cron.yml
+++ b/.github/workflows/dependabot-automerge-cron.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: write
-  issues: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -23,7 +23,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           quarantine-days: "1"
 
-      - if: steps.evaluate.outputs.quarantine-passed == 'true'
+      - if: steps.evaluate.outputs.candidate == 'true' && steps.evaluate.outputs.quarantine-passed == 'true'
         uses: cmiic/dependabot-automation/cron@6da55a5ce4f786ac1ec1c84b997b713ce28178c2 # v2.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -8,16 +8,23 @@ on:
       - synchronize
 
 permissions:
-  contents: write
-  issues: read
+  contents: write # the cron step merges via the pull request merge endpoint
   pull-requests: write
 
 jobs:
   automerge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: cmiic/dependabot-automation/merge@6da55a5ce4f786ac1ec1c84b997b713ce28178c2 # v2.1.0
+      - id: evaluate
+        uses: cmiic/dependabot-automation/merge@6da55a5ce4f786ac1ec1c84b997b713ce28178c2 # v2.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          quarantine-days: "1"
+
+      - if: steps.evaluate.outputs.quarantine-passed == 'true'
+        uses: cmiic/dependabot-automation/cron@6da55a5ce4f786ac1ec1c84b997b713ce28178c2 # v2.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           quarantine-days: "1"


### PR DESCRIPTION
Adopts the "combined wrapper" pattern from the dependabot-automation
README, which trades a slightly wider token for lower merge latency.

- Run the `cron` enforcer as a second step, gated on the evaluation's
  `quarantine-passed` output. The `merge` wrapper only writes an approval
  signal and then exits with `approved-awaiting-cron`; enforcement happened
  solely on the schedule. So a Dependabot rebase that re-validated an
  already-quarantined PR still waited up to 8 h for the next cron tick.
  The evaluator carries the quarantine timestamp forward across a rebase
  (same dependency key), so `quarantine-passed` is already true on that
  `synchronize` and the PR can merge immediately.
- Gate the job on `github.event.pull_request.user.login == 'dependabot[bot]'`.
  Both actions already filter internally; this stops a compromised action
  version from running at all on non-Dependabot PRs, which matters more now
  that this workflow holds `contents: write`. Deliberately keyed on the PR
  author rather than `github.actor`, so a human pushing to a Dependabot
  branch does not silently skip the run.
- Normalise permissions to the documented `contents: write` +
  `pull-requests: write`, dropping the redundant `issues: read`.

The scheduled cron wrapper stays: quarantine expiry is a time event, and a
PR that sees no further pushes is only ever picked up by the schedule.