### PR TITLE
ci: drop the redundant push trigger from CI

### DIFF
--- a/.github/workflows/makecode.yml
+++ b/.github/workflows/makecode.yml
@@ -1,10 +1,9 @@
 name: MakeCode
 
 on:
-  push:
-    branches: [master, main]
   pull_request:
     branches: [master, main]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
Branch protection already guarantees these checks passed on the pull
request before it could merge, so re-running them on push to the default
branch only duplicates work and burns runner minutes. Required checks are
unaffected: they are produced by the pull_request trigger, which stays.

Adds workflow_dispatch so the workflow can still be run by hand.